### PR TITLE
Fixup setup instruction in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,24 @@ Traktor::SongNameServer, tweet-from-traktor.pl and CamTwist "Traktor Song" plugi
 
 
 [Traktor::SongNameServer]
-Traktor::SongNameServer is a server, receives song names from Traktor and provides them for other applications.
+Traktor::SongNameServer is a kind of "fake" icecast server.  It receives song
+names from Traktor and provides them for other applications.
+
 It will work with other PCDJ softwares if they send icecast streaming protocols.
-To launch server, use songnameserver.pl .
+
+To run the script you need to ensure that Traktor is configured to write to the icecast server.
+
+![](https://atmos-s3itch.s3.amazonaws.com/skitched-20121022-122238.jpg)
+
+Enable broadcasting in Traktor's recorder panel.
+
+![](https://atmos-s3itch.s3.amazonaws.com/Traktor-20121022-122913.jpg)
+
+To launch server, execute it in a terminal and start playing some songs.
+
+```
+perl songnameserver.pl.
+```
 
 [tweet-from-traktor.pl]
 a script to post song names played by Traktor to twitter.


### PR DESCRIPTION
Addresses confusing I found in drumsoft/Traktor-SongNameServer#1

Fixes drumsoft/Traktor-SongNameServer#1
